### PR TITLE
Phase 5: File Sync Operations - CLAUDE.md Synchronization

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -92,6 +92,66 @@ program
     }
   });
 
+// Sync commands
+program
+  .command('sync')
+  .description('Sync preferences to CLAUDE.md files')
+  .option('--target <target>', 'Target: global, project, or all', 'all')
+  .option('--path <path>', 'Project path (required for project target)')
+  .option('--dry-run', 'Show what would be done without making changes')
+  .option('--no-backup', 'Skip creating backups')
+  .option('--no-merge', 'Overwrite instead of merging (project only)')
+  .action(async (options) => {
+    try {
+      const { syncGlobal, syncProject, syncAll } = await import('../src/commands/sync.js');
+
+      if (options.target === 'global') {
+        await syncGlobal(options);
+      } else if (options.target === 'project') {
+        await syncProject(options);
+      } else if (options.target === 'all') {
+        await syncAll(options);
+      } else {
+        error('Invalid target. Use: global, project, or all');
+        process.exit(1);
+      }
+    } catch (e) {
+      printError(e);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('backups')
+  .description('List available backups')
+  .option('--target <target>', 'Target: global or project', 'global')
+  .option('--path <path>', 'Project path (required for project target)')
+  .action(async (options) => {
+    try {
+      const { listBackups } = await import('../src/commands/sync.js');
+      await listBackups(options);
+    } catch (e) {
+      printError(e);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('restore')
+  .description('Restore from backup')
+  .requiredOption('--backup <path>', 'Path to backup file')
+  .option('--target <target>', 'Target: global or project', 'global')
+  .option('--path <path>', 'Project path (required for project target)')
+  .action(async (options) => {
+    try {
+      const { restoreBackup } = await import('../src/commands/sync.js');
+      await restoreBackup(options);
+    } catch (e) {
+      printError(e);
+      process.exit(1);
+    }
+  });
+
 // Wrapper installation commands
 program
   .command('install-wrappers')

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -1,0 +1,208 @@
+import { info, success, error, warn } from '../utils/logger.js';
+import { loadConfig } from '../config/index.js';
+import { createTransformer } from '../transformers/index.js';
+import { FileSync } from '../sync/file-sync.js';
+
+/**
+ * Sync preferences to global CLAUDE.md
+ */
+export async function syncGlobal(options = {}) {
+  const { dryRun = false, backup = true, verbose = false } = options;
+
+  try {
+    info('Loading preferences...');
+    const { config } = await loadConfig();
+
+    info('Transforming to CLAUDE.md format...');
+    const transformer = createTransformer('claude-md', config);
+    const content = await transformer.transform();
+
+    if (verbose) {
+      console.log('\n--- Transformed Content Preview ---');
+      console.log(content.substring(0, 500) + '...');
+      console.log('--- End Preview ---\n');
+    }
+
+    const fileSync = new FileSync();
+    const result = await fileSync.syncGlobal(content, { dryRun, backup });
+
+    if (result.dryRun) {
+      info('Dry run complete - no changes made');
+      info(`Would write to: ${result.path}`);
+    } else {
+      success(`Global CLAUDE.md updated: ${result.path}`);
+      if (backup) {
+        info('Previous version backed up');
+      }
+    }
+
+    return result;
+  } catch (e) {
+    error(`Sync to global CLAUDE.md failed: ${e.message}`);
+    throw e;
+  }
+}
+
+/**
+ * Sync preferences to project CLAUDE.md
+ */
+export async function syncProject(options = {}) {
+  const { path: projectPath, dryRun = false, backup = true, noMerge = false } = options;
+
+  if (!projectPath) {
+    error('Project path required: --path <repo-path>');
+    throw new Error('Project path required');
+  }
+
+  try {
+    info('Loading preferences...');
+    const { config } = await loadConfig();
+
+    info('Generating project preferences overlay...');
+    const transformer = createTransformer('claude-md', config);
+    const content = await transformer.transform();
+
+    const fileSync = new FileSync();
+    const result = await fileSync.syncProject(content, projectPath, {
+      dryRun,
+      backup,
+      noMerge
+    });
+
+    if (result.dryRun) {
+      info('Dry run complete - no changes made');
+      info(`Would write to: ${result.path}`);
+      info(`Mode: ${noMerge ? 'Overwrite' : 'Merge'}`);
+    } else {
+      success(`Project CLAUDE.md updated: ${result.path}`);
+      if (result.merged) {
+        info('Merged with existing project content');
+      }
+      if (backup) {
+        info('Previous version backed up');
+      }
+    }
+
+    return result;
+  } catch (e) {
+    error(`Sync to project CLAUDE.md failed: ${e.message}`);
+    throw e;
+  }
+}
+
+/**
+ * Sync preferences to all targets
+ */
+export async function syncAll(options = {}) {
+  info('Syncing to all targets...\n');
+
+  const results = {
+    global: null,
+    errors: []
+  };
+
+  // Sync global CLAUDE.md
+  try {
+    info('Syncing global CLAUDE.md...');
+    results.global = await syncGlobal(options);
+  } catch (e) {
+    results.errors.push({ target: 'global', error: e.message });
+    warn(`Failed to sync global CLAUDE.md: ${e.message}`);
+  }
+
+  // Summary
+  console.log('\n' + '='.repeat(50));
+  if (results.errors.length === 0) {
+    success('✓ All targets synced successfully!');
+  } else {
+    warn(`⚠ Completed with ${results.errors.length} error(s):`);
+    results.errors.forEach(({ target, error }) => {
+      warn(`  - ${target}: ${error}`);
+    });
+  }
+
+  return results;
+}
+
+/**
+ * List available backups
+ */
+export async function listBackups(options = {}) {
+  const { target = 'global', path: projectPath } = options;
+
+  try {
+    const fileSync = new FileSync();
+    let targetPath;
+
+    if (target === 'global') {
+      targetPath = fileSync.globalCLAUDEPath;
+    } else if (target === 'project') {
+      if (!projectPath) {
+        error('Project path required for project backups: --path <repo-path>');
+        throw new Error('Project path required');
+      }
+      targetPath = await fileSync.findProjectCLAUDE(projectPath);
+    } else {
+      error('Invalid target. Use: global or project');
+      throw new Error('Invalid target');
+    }
+
+    const backups = await fileSync.listBackups(targetPath);
+
+    if (backups.length === 0) {
+      info(`No backups found for ${target} CLAUDE.md`);
+    } else {
+      success(`Found ${backups.length} backup(s) for ${target} CLAUDE.md:`);
+      backups.forEach((backup, i) => {
+        console.log(`  ${i + 1}. ${backup}`);
+      });
+    }
+
+    return backups;
+  } catch (e) {
+    error(`Failed to list backups: ${e.message}`);
+    throw e;
+  }
+}
+
+/**
+ * Restore from backup
+ */
+export async function restoreBackup(options = {}) {
+  const { target = 'global', path: projectPath, backup: backupPath } = options;
+
+  if (!backupPath) {
+    error('Backup path required: --backup <backup-file>');
+    throw new Error('Backup path required');
+  }
+
+  try {
+    const fileSync = new FileSync();
+    let targetPath;
+
+    if (target === 'global') {
+      targetPath = fileSync.globalCLAUDEPath;
+    } else if (target === 'project') {
+      if (!projectPath) {
+        error('Project path required for project restore: --path <repo-path>');
+        throw new Error('Project path required');
+      }
+      targetPath = await fileSync.findProjectCLAUDE(projectPath);
+    } else {
+      error('Invalid target. Use: global or project');
+      throw new Error('Invalid target');
+    }
+
+    info(`Restoring ${target} CLAUDE.md from backup...`);
+    const result = await fileSync.restoreBackup(backupPath, targetPath);
+
+    success(`Restored ${target} CLAUDE.md from backup`);
+    info(`Target: ${result.path}`);
+    info(`Backup: ${result.restoredFrom}`);
+
+    return result;
+  } catch (e) {
+    error(`Failed to restore backup: ${e.message}`);
+    throw e;
+  }
+}

--- a/src/sync/file-sync.js
+++ b/src/sync/file-sync.js
@@ -1,0 +1,182 @@
+import { join, dirname } from 'path';
+import { homedir } from 'os';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+
+/**
+ * Manages file synchronization for CLAUDE.md files
+ */
+export class FileSync {
+  constructor() {
+    // Claude Code stores CLAUDE.md in ~/.claude/
+    this.globalCLAUDEPath = join(homedir(), '.claude', 'CLAUDE.md');
+  }
+
+  /**
+   * Sync content to global CLAUDE.md
+   */
+  async syncGlobal(content, options = {}) {
+    const { backup = true, dryRun = false } = options;
+
+    if (dryRun) {
+      console.log('DRY RUN - Would write to:', this.globalCLAUDEPath);
+      console.log('Content preview:', content.substring(0, 200) + '...');
+      return { success: true, dryRun: true, path: this.globalCLAUDEPath };
+    }
+
+    // Ensure directory exists
+    const dir = dirname(this.globalCLAUDEPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    // Backup existing file
+    if (backup && existsSync(this.globalCLAUDEPath)) {
+      await this.createBackup(this.globalCLAUDEPath);
+    }
+
+    // Write new content
+    writeFileSync(this.globalCLAUDEPath, content, 'utf-8');
+
+    return { success: true, path: this.globalCLAUDEPath };
+  }
+
+  /**
+   * Sync content to project CLAUDE.md
+   */
+  async syncProject(content, projectPath, options = {}) {
+    const { backup = true, dryRun = false, noMerge = false } = options;
+
+    // Find CLAUDE.md in project
+    const projectCLAUDEPath = await this.findProjectCLAUDE(projectPath);
+
+    if (dryRun) {
+      console.log('DRY RUN - Would write to:', projectCLAUDEPath);
+      console.log('Mode:', noMerge ? 'Overwrite' : 'Merge');
+      console.log('Content preview:', content.substring(0, 200) + '...');
+      return { success: true, dryRun: true, path: projectCLAUDEPath };
+    }
+
+    let finalContent = content;
+
+    // Merge with existing content if requested
+    if (!noMerge && existsSync(projectCLAUDEPath)) {
+      const existing = readFileSync(projectCLAUDEPath, 'utf-8');
+      finalContent = this.mergeContent(existing, content);
+    }
+
+    // Backup existing file
+    if (backup && existsSync(projectCLAUDEPath)) {
+      await this.createBackup(projectCLAUDEPath);
+    }
+
+    // Ensure directory exists
+    const dir = dirname(projectCLAUDEPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    // Write merged content
+    writeFileSync(projectCLAUDEPath, finalContent, 'utf-8');
+
+    return { success: true, path: projectCLAUDEPath, merged: !noMerge };
+  }
+
+  /**
+   * Find CLAUDE.md in project directory
+   */
+  async findProjectCLAUDE(projectPath) {
+    // Check .claude/CLAUDE.md first (new standard location)
+    const claudePath = join(projectPath, '.claude', 'CLAUDE.md');
+    if (existsSync(claudePath)) {
+      return claudePath;
+    }
+
+    // Check root CLAUDE.md (legacy)
+    const rootPath = join(projectPath, 'CLAUDE.md');
+    if (existsSync(rootPath)) {
+      return rootPath;
+    }
+
+    // Default to .claude/CLAUDE.md for new files
+    return claudePath;
+  }
+
+  /**
+   * Merge new user preferences with existing project content
+   */
+  mergeContent(existing, newUserPreferences) {
+    // Look for project context marker
+    const projectMarker = '# PROJECT CONTEXT';
+    const separatorMarker = '---\n\n# PROJECT CONTEXT';
+
+    if (existing.includes(projectMarker)) {
+      // Find where project context starts
+      const markerIndex = existing.indexOf(projectMarker);
+      const projectContext = existing.substring(markerIndex);
+
+      // Replace user preferences, keep project context
+      return newUserPreferences.trim() + '\n\n---\n\n' + projectContext;
+    } else {
+      // No clear separation - prepend user preferences
+      return newUserPreferences.trim() + '\n\n---\n\n' + existing;
+    }
+  }
+
+  /**
+   * Create timestamped backup of file
+   */
+  async createBackup(filePath) {
+    const now = new Date();
+    const timestamp = now.toISOString()
+      .replace(/:/g, '-')
+      .replace(/\..+$/, '')
+      .replace('T', '-') + '-' + now.getMilliseconds().toString().padStart(3, '0');
+
+    const backupPath = `${filePath}.backup.${timestamp}`;
+    const content = readFileSync(filePath, 'utf-8');
+    writeFileSync(backupPath, content, 'utf-8');
+
+    return backupPath;
+  }
+
+  /**
+   * List available backups for a file
+   */
+  async listBackups(filePath) {
+    const dir = dirname(filePath);
+    const filename = filePath.split(/[/\\]/).pop();
+
+    if (!existsSync(dir)) {
+      return [];
+    }
+
+    const { readdirSync } = await import('fs');
+    const files = readdirSync(dir);
+
+    return files
+      .filter(f => f.startsWith(`${filename}.backup.`))
+      .map(f => join(dir, f))
+      .sort()
+      .reverse(); // Most recent first
+  }
+
+  /**
+   * Restore from backup
+   */
+  async restoreBackup(backupPath, targetPath) {
+    if (!existsSync(backupPath)) {
+      throw new Error(`Backup not found: ${backupPath}`);
+    }
+
+    const content = readFileSync(backupPath, 'utf-8');
+
+    // Backup current file before restoring
+    if (existsSync(targetPath)) {
+      await this.createBackup(targetPath);
+    }
+
+    writeFileSync(targetPath, content, 'utf-8');
+
+    return { success: true, path: targetPath, restoredFrom: backupPath };
+  }
+}

--- a/tests/commands/sync.test.js
+++ b/tests/commands/sync.test.js
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { syncGlobal, syncProject, syncAll, listBackups, restoreBackup } from '../../src/commands/sync.js';
+
+// Mock dependencies
+vi.mock('../../src/config/index.js');
+vi.mock('../../src/transformers/index.js');
+vi.mock('../../src/sync/file-sync.js');
+vi.mock('../../src/utils/logger.js');
+
+describe('Sync Commands', () => {
+  let mockConfig;
+  let mockTransformer;
+  let mockFileSync;
+  let mockLogger;
+
+  beforeEach(async () => {
+    // Reset all mocks
+    vi.clearAllMocks();
+
+    // Mock config
+    mockConfig = { loadConfig: vi.fn() };
+    const configModule = await import('../../src/config/index.js');
+    configModule.loadConfig = vi.fn().mockResolvedValue({
+      config: {
+        professional_background: { experience: '15 years' },
+        working_style: { communication: ['Concise'] }
+      }
+    });
+
+    // Mock transformer
+    mockTransformer = {
+      transform: vi.fn().mockResolvedValue('# Transformed Content')
+    };
+    const transformerModule = await import('../../src/transformers/index.js');
+    transformerModule.createTransformer = vi.fn().mockReturnValue(mockTransformer);
+
+    // Mock FileSync
+    mockFileSync = {
+      syncGlobal: vi.fn().mockResolvedValue({ success: true, path: '~/.claude/CLAUDE.md' }),
+      syncProject: vi.fn().mockResolvedValue({ success: true, path: '/project/.claude/CLAUDE.md', merged: true }),
+      findProjectCLAUDE: vi.fn().mockResolvedValue('/project/.claude/CLAUDE.md'),
+      listBackups: vi.fn().mockResolvedValue([]),
+      restoreBackup: vi.fn().mockResolvedValue({ success: true, path: '~/.claude/CLAUDE.md', restoredFrom: 'backup.md' }),
+      globalCLAUDEPath: '~/.claude/CLAUDE.md'
+    };
+    const fileSyncModule = await import('../../src/sync/file-sync.js');
+    fileSyncModule.FileSync = vi.fn().mockImplementation(() => mockFileSync);
+
+    // Mock logger
+    const loggerModule = await import('../../src/utils/logger.js');
+    mockLogger = {
+      info: vi.fn(),
+      success: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn()
+    };
+    loggerModule.info = mockLogger.info;
+    loggerModule.success = mockLogger.success;
+    loggerModule.error = mockLogger.error;
+    loggerModule.warn = mockLogger.warn;
+  });
+
+  describe('syncGlobal', () => {
+    it('should sync preferences to global CLAUDE.md', async () => {
+      const result = await syncGlobal();
+
+      expect(result.success).toBe(true);
+      expect(mockFileSync.syncGlobal).toHaveBeenCalledWith(
+        '# Transformed Content',
+        expect.objectContaining({ dryRun: false, backup: true })
+      );
+      expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining('Global CLAUDE.md updated'));
+    });
+
+    it('should perform dry run when requested', async () => {
+      mockFileSync.syncGlobal.mockResolvedValue({ success: true, dryRun: true, path: '~/.claude/CLAUDE.md' });
+
+      const result = await syncGlobal({ dryRun: true });
+
+      expect(result.dryRun).toBe(true);
+      expect(mockFileSync.syncGlobal).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ dryRun: true })
+      );
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('Dry run complete'));
+    });
+
+    it('should skip backup when backup option is false', async () => {
+      await syncGlobal({ backup: false });
+
+      expect(mockFileSync.syncGlobal).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ backup: false })
+      );
+    });
+
+    it('should show verbose output when verbose is true', async () => {
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await syncGlobal({ verbose: true });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('Transformed Content Preview'));
+
+      consoleLogSpy.mockRestore();
+    });
+
+    it('should throw error on failure', async () => {
+      mockFileSync.syncGlobal.mockRejectedValue(new Error('Write failed'));
+
+      await expect(syncGlobal()).rejects.toThrow('Write failed');
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('failed'));
+    });
+  });
+
+  describe('syncProject', () => {
+    it('should sync preferences to project CLAUDE.md', async () => {
+      const result = await syncProject({ path: '/project' });
+
+      expect(result.success).toBe(true);
+      expect(mockFileSync.syncProject).toHaveBeenCalledWith(
+        '# Transformed Content',
+        '/project',
+        expect.objectContaining({ dryRun: false, backup: true, noMerge: false })
+      );
+      expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining('Project CLAUDE.md updated'));
+    });
+
+    it('should throw error if path is not provided', async () => {
+      await expect(syncProject({})).rejects.toThrow('Project path required');
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('required'));
+    });
+
+    it('should perform dry run when requested', async () => {
+      mockFileSync.syncProject.mockResolvedValue({ success: true, dryRun: true, path: '/project/.claude/CLAUDE.md' });
+
+      const result = await syncProject({ path: '/project', dryRun: true });
+
+      expect(result.dryRun).toBe(true);
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('Dry run complete'));
+    });
+
+    it('should indicate merge when content is merged', async () => {
+      mockFileSync.syncProject.mockResolvedValue({ success: true, path: '/project/.claude/CLAUDE.md', merged: true });
+
+      await syncProject({ path: '/project' });
+
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('Merged with existing'));
+    });
+
+    it('should use noMerge option when specified', async () => {
+      mockFileSync.syncProject.mockResolvedValue({ success: true, path: '/project/.claude/CLAUDE.md', merged: false });
+
+      await syncProject({ path: '/project', noMerge: true });
+
+      expect(mockFileSync.syncProject).toHaveBeenCalledWith(
+        expect.any(String),
+        '/project',
+        expect.objectContaining({ noMerge: true })
+      );
+    });
+
+    it('should throw error on failure', async () => {
+      mockFileSync.syncProject.mockRejectedValue(new Error('Write failed'));
+
+      await expect(syncProject({ path: '/project' })).rejects.toThrow('Write failed');
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('failed'));
+    });
+  });
+
+  describe('syncAll', () => {
+    it('should sync to global target', async () => {
+      const result = await syncAll();
+
+      expect(result.global).toBeDefined();
+      expect(result.global.success).toBe(true);
+      expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining('All targets synced'));
+    });
+
+    it('should continue even if global sync fails', async () => {
+      mockFileSync.syncGlobal.mockRejectedValue(new Error('Global failed'));
+
+      const result = await syncAll();
+
+      expect(result.errors.length).toBe(1);
+      expect(result.errors[0].target).toBe('global');
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('error'));
+    });
+
+    it('should pass options to sync operations', async () => {
+      await syncAll({ dryRun: true, backup: false });
+
+      expect(mockFileSync.syncGlobal).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ dryRun: true, backup: false })
+      );
+    });
+  });
+
+  describe('listBackups', () => {
+    it('should list backups for global target', async () => {
+      mockFileSync.listBackups.mockResolvedValue(['backup1.md', 'backup2.md']);
+
+      const result = await listBackups({ target: 'global' });
+
+      expect(result).toEqual(['backup1.md', 'backup2.md']);
+      expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining('Found 2 backup'));
+    });
+
+    it('should list backups for project target', async () => {
+      mockFileSync.listBackups.mockResolvedValue(['backup1.md']);
+
+      await listBackups({ target: 'project', path: '/project' });
+
+      expect(mockFileSync.findProjectCLAUDE).toHaveBeenCalledWith('/project');
+      expect(mockFileSync.listBackups).toHaveBeenCalled();
+    });
+
+    it('should throw error if project path not provided', async () => {
+      await expect(listBackups({ target: 'project' })).rejects.toThrow('Project path required');
+    });
+
+    it('should throw error for invalid target', async () => {
+      await expect(listBackups({ target: 'invalid' })).rejects.toThrow('Invalid target');
+    });
+
+    it('should handle no backups gracefully', async () => {
+      mockFileSync.listBackups.mockResolvedValue([]);
+
+      await listBackups({ target: 'global' });
+
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('No backups found'));
+    });
+  });
+
+  describe('restoreBackup', () => {
+    it('should restore backup for global target', async () => {
+      const result = await restoreBackup({ target: 'global', backup: 'backup.md' });
+
+      expect(result.success).toBe(true);
+      expect(mockFileSync.restoreBackup).toHaveBeenCalledWith('backup.md', '~/.claude/CLAUDE.md');
+      expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining('Restored'));
+    });
+
+    it('should restore backup for project target', async () => {
+      await restoreBackup({ target: 'project', path: '/project', backup: 'backup.md' });
+
+      expect(mockFileSync.findProjectCLAUDE).toHaveBeenCalledWith('/project');
+      expect(mockFileSync.restoreBackup).toHaveBeenCalled();
+    });
+
+    it('should throw error if backup path not provided', async () => {
+      await expect(restoreBackup({ target: 'global' })).rejects.toThrow('Backup path required');
+    });
+
+    it('should throw error if project path not provided', async () => {
+      await expect(restoreBackup({ target: 'project', backup: 'backup.md' })).rejects.toThrow('Project path required');
+    });
+
+    it('should throw error for invalid target', async () => {
+      await expect(restoreBackup({ target: 'invalid', backup: 'backup.md' })).rejects.toThrow('Invalid target');
+    });
+
+    it('should throw error on restore failure', async () => {
+      mockFileSync.restoreBackup.mockRejectedValue(new Error('Restore failed'));
+
+      await expect(restoreBackup({ target: 'global', backup: 'backup.md' })).rejects.toThrow('Restore failed');
+    });
+  });
+});

--- a/tests/sync/file-sync.test.js
+++ b/tests/sync/file-sync.test.js
@@ -1,0 +1,349 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { FileSync } from '../../src/sync/file-sync.js';
+import { join } from 'path';
+import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, readdirSync } from 'fs';
+import { tmpdir } from 'os';
+
+describe('FileSync', () => {
+  let testDir;
+  let fileSync;
+
+  beforeEach(() => {
+    // Create temp directory for tests
+    testDir = join(tmpdir(), `file-sync-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+    fileSync = new FileSync();
+  });
+
+  afterEach(() => {
+    // Clean up test directory
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('findProjectCLAUDE', () => {
+    it('should find CLAUDE.md in .claude/ directory', async () => {
+      const claudeDir = join(testDir, '.claude');
+      mkdirSync(claudeDir, { recursive: true });
+      writeFileSync(join(claudeDir, 'CLAUDE.md'), '# Test', 'utf-8');
+
+      const found = await fileSync.findProjectCLAUDE(testDir);
+
+      expect(found).toContain('.claude');
+      expect(found).toContain('CLAUDE.md');
+    });
+
+    it('should find CLAUDE.md in root directory (legacy)', async () => {
+      writeFileSync(join(testDir, 'CLAUDE.md'), '# Test', 'utf-8');
+
+      const found = await fileSync.findProjectCLAUDE(testDir);
+
+      expect(found).toBe(join(testDir, 'CLAUDE.md'));
+    });
+
+    it('should prefer .claude/CLAUDE.md over root', async () => {
+      const claudeDir = join(testDir, '.claude');
+      mkdirSync(claudeDir, { recursive: true });
+      writeFileSync(join(claudeDir, 'CLAUDE.md'), '# Claude Dir', 'utf-8');
+      writeFileSync(join(testDir, 'CLAUDE.md'), '# Root', 'utf-8');
+
+      const found = await fileSync.findProjectCLAUDE(testDir);
+
+      expect(found).toContain('.claude');
+    });
+
+    it('should return default .claude/CLAUDE.md path if neither exists', async () => {
+      const found = await fileSync.findProjectCLAUDE(testDir);
+
+      expect(found).toBe(join(testDir, '.claude', 'CLAUDE.md'));
+    });
+  });
+
+  describe('mergeContent', () => {
+    it('should preserve project context when marker exists', () => {
+      const existing = `
+# Some User Content
+
+---
+
+# PROJECT CONTEXT
+## Tech Stack
+- Node.js
+- React
+`;
+
+      const newPrefs = `
+# Working with User
+## Communication Style
+- Concise bullets
+`;
+
+      const merged = fileSync.mergeContent(existing, newPrefs);
+
+      expect(merged).toContain('Working with User');
+      expect(merged).toContain('PROJECT CONTEXT');
+      expect(merged).toContain('Tech Stack');
+      expect(merged).toContain('Node.js');
+      expect(merged).not.toContain('Some User Content');
+    });
+
+    it('should prepend user preferences when no project marker exists', () => {
+      const existing = `
+# Existing Content
+Some text here
+`;
+
+      const newPrefs = `
+# Working with User
+User preferences
+`;
+
+      const merged = fileSync.mergeContent(existing, newPrefs);
+
+      expect(merged).toContain('Working with User');
+      expect(merged).toContain('Existing Content');
+      expect(merged.indexOf('Working with User')).toBeLessThan(merged.indexOf('Existing Content'));
+    });
+  });
+
+  describe('createBackup', () => {
+    it('should create timestamped backup file', async () => {
+      const filePath = join(testDir, 'test.md');
+      writeFileSync(filePath, '# Original Content', 'utf-8');
+
+      const backupPath = await fileSync.createBackup(filePath);
+
+      expect(existsSync(backupPath)).toBe(true);
+      expect(backupPath).toMatch(/test\.md\.backup\.\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}/);
+
+      const backupContent = readFileSync(backupPath, 'utf-8');
+      expect(backupContent).toBe('# Original Content');
+    });
+
+    it('should preserve original file when creating backup', async () => {
+      const filePath = join(testDir, 'test.md');
+      const originalContent = '# Original Content';
+      writeFileSync(filePath, originalContent, 'utf-8');
+
+      await fileSync.createBackup(filePath);
+
+      const currentContent = readFileSync(filePath, 'utf-8');
+      expect(currentContent).toBe(originalContent);
+    });
+  });
+
+  describe('syncGlobal', () => {
+    it('should perform dry run without writing', async () => {
+      const content = '# Test Content';
+
+      const result = await fileSync.syncGlobal(content, { dryRun: true });
+
+      expect(result.success).toBe(true);
+      expect(result.dryRun).toBe(true);
+      expect(result.path).toBeDefined();
+    });
+
+    it('should create directory if it does not exist', async () => {
+      const testSync = new FileSync();
+      const testPath = join(testDir, '.claude', 'CLAUDE.md');
+      testSync.globalCLAUDEPath = testPath;
+
+      const content = '# Test Content';
+
+      const result = await testSync.syncGlobal(content, { backup: false });
+
+      expect(result.success).toBe(true);
+      expect(existsSync(testPath)).toBe(true);
+
+      const written = readFileSync(testPath, 'utf-8');
+      expect(written).toBe(content);
+    });
+
+    it('should create backup before overwriting', async () => {
+      const testSync = new FileSync();
+      const testPath = join(testDir, 'CLAUDE.md');
+      testSync.globalCLAUDEPath = testPath;
+
+      writeFileSync(testPath, '# Original', 'utf-8');
+
+      await testSync.syncGlobal('# New Content', { backup: true });
+
+      const backups = readdirSync(testDir).filter(f => f.includes('.backup.'));
+      expect(backups.length).toBe(1);
+    });
+
+    it('should skip backup when backup option is false', async () => {
+      const testSync = new FileSync();
+      const testPath = join(testDir, 'CLAUDE.md');
+      testSync.globalCLAUDEPath = testPath;
+
+      writeFileSync(testPath, '# Original', 'utf-8');
+
+      await testSync.syncGlobal('# New Content', { backup: false });
+
+      const backups = readdirSync(testDir).filter(f => f.includes('.backup.'));
+      expect(backups.length).toBe(0);
+    });
+  });
+
+  describe('syncProject', () => {
+    it('should perform dry run without writing', async () => {
+      const content = '# Test Content';
+
+      const result = await fileSync.syncProject(content, testDir, { dryRun: true });
+
+      expect(result.success).toBe(true);
+      expect(result.dryRun).toBe(true);
+      expect(result.path).toBeDefined();
+    });
+
+    it('should write to .claude/CLAUDE.md by default', async () => {
+      const content = '# Test Content';
+
+      const result = await fileSync.syncProject(content, testDir, { backup: false });
+
+      expect(result.success).toBe(true);
+      expect(result.path).toContain('.claude');
+      expect(existsSync(result.path)).toBe(true);
+
+      const written = readFileSync(result.path, 'utf-8');
+      expect(written).toBe(content);
+    });
+
+    it('should merge with existing content by default', async () => {
+      const claudeDir = join(testDir, '.claude');
+      mkdirSync(claudeDir, { recursive: true });
+      const claudePath = join(claudeDir, 'CLAUDE.md');
+
+      const existing = `
+# Existing Preferences
+
+---
+
+# PROJECT CONTEXT
+## Tech Stack
+- Node.js
+`;
+      writeFileSync(claudePath, existing, 'utf-8');
+
+      const newContent = '# New Preferences\n## Style\n- Concise';
+
+      const result = await fileSync.syncProject(newContent, testDir, { backup: false });
+
+      expect(result.merged).toBe(true);
+
+      const written = readFileSync(result.path, 'utf-8');
+      expect(written).toContain('New Preferences');
+      expect(written).toContain('PROJECT CONTEXT');
+      expect(written).toContain('Tech Stack');
+    });
+
+    it('should overwrite when noMerge is true', async () => {
+      const claudeDir = join(testDir, '.claude');
+      mkdirSync(claudeDir, { recursive: true });
+      const claudePath = join(claudeDir, 'CLAUDE.md');
+
+      writeFileSync(claudePath, '# Old Content', 'utf-8');
+
+      const newContent = '# New Content';
+
+      const result = await fileSync.syncProject(newContent, testDir, {
+        backup: false,
+        noMerge: true
+      });
+
+      expect(result.merged).toBe(false);
+
+      const written = readFileSync(result.path, 'utf-8');
+      expect(written).toBe(newContent);
+      expect(written).not.toContain('Old Content');
+    });
+  });
+
+  describe('listBackups', () => {
+    it('should list all backups for a file', async () => {
+      const filePath = join(testDir, 'test.md');
+      writeFileSync(filePath, '# V1', 'utf-8');
+
+      // Create multiple backups
+      await fileSync.createBackup(filePath);
+      writeFileSync(filePath, '# V2', 'utf-8');
+      await fileSync.createBackup(filePath);
+      writeFileSync(filePath, '# V3', 'utf-8');
+      await fileSync.createBackup(filePath);
+
+      const backups = await fileSync.listBackups(filePath);
+
+      expect(backups.length).toBe(3);
+      expect(backups[0]).toMatch(/test\.md\.backup\./);
+    });
+
+    it('should return empty array when no backups exist', async () => {
+      const filePath = join(testDir, 'test.md');
+
+      const backups = await fileSync.listBackups(filePath);
+
+      expect(backups).toEqual([]);
+    });
+
+    it('should return backups in reverse chronological order', async () => {
+      const filePath = join(testDir, 'test.md');
+      writeFileSync(filePath, '# V1', 'utf-8');
+
+      await fileSync.createBackup(filePath);
+      await new Promise(resolve => setTimeout(resolve, 1000)); // Wait 1s
+      writeFileSync(filePath, '# V2', 'utf-8');
+      await fileSync.createBackup(filePath);
+
+      const backups = await fileSync.listBackups(filePath);
+
+      // Most recent should be first
+      expect(backups[0] > backups[1]).toBe(true);
+    });
+  });
+
+  describe('restoreBackup', () => {
+    it('should restore content from backup', async () => {
+      const filePath = join(testDir, 'test.md');
+      writeFileSync(filePath, '# Original', 'utf-8');
+
+      const backupPath = await fileSync.createBackup(filePath);
+      writeFileSync(filePath, '# Modified', 'utf-8');
+
+      const result = await fileSync.restoreBackup(backupPath, filePath);
+
+      expect(result.success).toBe(true);
+      expect(result.path).toBe(filePath);
+
+      const restored = readFileSync(filePath, 'utf-8');
+      expect(restored).toBe('# Original');
+    });
+
+    it('should throw error if backup does not exist', async () => {
+      const backupPath = join(testDir, 'nonexistent.backup');
+      const targetPath = join(testDir, 'test.md');
+
+      await expect(fileSync.restoreBackup(backupPath, targetPath)).rejects.toThrow('Backup not found');
+    });
+
+    it('should create backup of current file before restoring', async () => {
+      const filePath = join(testDir, 'test.md');
+      writeFileSync(filePath, '# Original', 'utf-8');
+
+      const backupPath = await fileSync.createBackup(filePath);
+      writeFileSync(filePath, '# Modified', 'utf-8');
+
+      const result = await fileSync.restoreBackup(backupPath, filePath);
+
+      // Verify restore worked
+      expect(result.success).toBe(true);
+      const restored = readFileSync(filePath, 'utf-8');
+      expect(restored).toBe('# Original');
+
+      // Should have at least one backup (the "Modified" version before restore)
+      const backups = await fileSync.listBackups(filePath);
+      expect(backups.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements file synchronization for global and project-specific CLAUDE.md files, completing the sync functionality for Claude Code environments.

## Changes

**Core Features:**
- ✅ Global CLAUDE.md sync to `~/.claude/CLAUDE.md`
- ✅ Project CLAUDE.md sync with intelligent merge strategy
- ✅ Timestamped backup system with millisecond precision
- ✅ Restore functionality from backups
- ✅ Dry-run mode for safe testing
- ✅ Support for both `.claude/CLAUDE.md` (new) and root `CLAUDE.md` (legacy)

**Implementation Details:**

### FileSync Class (`src/sync/file-sync.js`)
- `syncGlobal()` - Write to global CLAUDE.md location
- `syncProject()` - Write/merge to project CLAUDE.md  
- `findProjectCLAUDE()` - Auto-detect CLAUDE.md location
- `mergeContent()` - Smart merge preserving PROJECT CONTEXT
- `createBackup()` - Timestamped backups with milliseconds
- `listBackups()` - List available backups
- `restoreBackup()` - Restore from backup

### Sync Commands (`src/commands/sync.js`)
- `syncGlobal()` - Sync to global CLAUDE.md
- `syncProject()` - Sync to project with merge support  
- `syncAll()` - Sync to all targets
- `listBackups()` - View available backups
- `restoreBackup()` - Restore from backup

### CLI Commands
```bash
# Sync commands
claude-context-sync sync --target <global|project|all>
claude-context-sync backups --target <global|project>
claude-context-sync restore --backup <path>
```

## Content Merging Strategy

- Detects `# PROJECT CONTEXT` marker to preserve project-specific content
- Replaces user preferences while keeping project sections intact
- Falls back to prepending user prefs if no marker found

## Test Coverage

- ✅ 22 comprehensive tests for FileSync operations
- ✅ 25 tests for sync commands
- ✅ All 190 tests passing (including existing 143)

## Usage Examples

```bash
# Sync to global CLAUDE.md
claude-context-sync sync --target global

# Sync to project (merge mode)
claude-context-sync sync --target project --path ~/my-repo

# Sync to project (overwrite mode)  
claude-context-sync sync --target project --path ~/my-repo --no-merge

# Dry run
claude-context-sync sync --target all --dry-run

# List backups
claude-context-sync backups --target global

# Restore from backup
claude-context-sync restore --backup ~/.claude/CLAUDE.md.backup.2025-10-02-14-30-45-123
```

## Files Changed

- `bin/cli.js` - Added sync, backups, and restore commands
- `src/sync/file-sync.js` - New FileSync class
- `src/commands/sync.js` - New sync command handlers
- `tests/sync/file-sync.test.js` - FileSync unit tests
- `tests/commands/sync.test.js` - Sync command tests

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #5